### PR TITLE
Fix for issue 52, HTTPS location fails to add

### DIFF
--- a/src/org/sparkleshare/android/WelcomeActivity.java
+++ b/src/org/sparkleshare/android/WelcomeActivity.java
@@ -8,6 +8,7 @@ import android.os.Bundle;
 import android.support.v4.app.FragmentActivity;
 import android.view.View;
 import android.widget.Toast;
+import android.view.KeyEvent;
 
 import com.google.zxing.integration.android.IntentIntegrator;
 import com.google.zxing.integration.android.IntentResult;
@@ -70,4 +71,16 @@ public class WelcomeActivity extends FragmentActivity {
 		}
 	}
 
+	@Override
+	public boolean onKeyDown (int keyCode, KeyEvent event)
+	{
+		switch(keyCode)
+		{
+			case KeyEvent.KEYCODE_MENU:
+			Intent settings = new Intent(this, SettingsActivity.class);
+			startActivity(settings);
+			return true;
+		}
+		return false;
+	}
 }


### PR DESCRIPTION
This patch allow to open settings in Welcome Screen by menu key and allow change Option
Accept all SSL certificates.
This Fix issue https://github.com/NewProggie/SparkleShare-Android/issues/52
